### PR TITLE
feat: Create global state for player data and AP

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js/dist/umd/supabase.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/lucide@0.255.0/dist/umd/lucide.min.js"></script>
     <script src="js/supabase.js"></script>
+    <script src="js/current-player.js"></script>
     <script src="https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js"></script>
     <script src="js/actions-ui.js"></script>
     <script src="js/detail.zone.js" defer></script>

--- a/js/auth.js
+++ b/js/auth.js
@@ -86,6 +86,7 @@ function initAuthForms() {
 
       console.log("Login exitoso, cambiando hash a #games");
       await ensurePlayer(); // Asegura que el jugador exista
+      await initializeCurrentPlayer(); // Carga datos del jugador en el estado global
       window.location.hash = "games";
     });
     liForm._init = true;
@@ -126,6 +127,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   } = await supabase.auth.getSession();
   console.log("getSession →", { session, sessionErr });
   if (session) {
+    await initializeCurrentPlayer(); // Carga datos del jugador en el estado global
     // Si estamos en welcome o sin hash, navegamos a games; si ya estamos en game, no tocamos
     const current = window.location.hash.slice(1) || "welcome";
     if (current === "welcome" || current === "" || current === "login") {

--- a/js/game.js
+++ b/js/game.js
@@ -134,6 +134,10 @@ async function renderPlayersStatus(gameId, nightId = null) {
     .map((p) => {
       const used = usedMap[p.player_id] || 0;
       const remaining = Math.max(2 - used, 0);
+      // Si este es el jugador actual, actualizamos su estado global de AP
+      if (p.player_id === window.currentPlayer?.id) {
+        setCurrentPlayerAP(remaining);
+      }
       const display = remaining > 0 ? remaining : "✓";
       return `
       <div class="player-item">


### PR DESCRIPTION
Introduces a global state for the current player's data, including their ID, name, and remaining Action Points (AP). This makes the player's AP available throughout the application, avoiding repeated database calls.

Key changes:
- Adds a new file `js/current-player.js` to manage the `window.currentPlayer` global object.
- Modifies the authentication flow in `js/auth.js` to initialize this player data on login.
- Updates the player status rendering in `js/game.js` to also update the global AP state.
- Refactors `js/actions-ui.js` to use the global state for AP checks.
- Implements the core feature request: the "Actuar en la Zona" button is now disabled if the player has 0 AP.

Note: Frontend verification was attempted using a Playwright script, but was blocked by persistent issues in the testing environment related to the application's routing and form submission logic. The code changes have been manually reviewed and are believed to be correct.