### PR TITLE
feat: character sheet skeleton + remove map background

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -282,24 +282,13 @@ button,
 }
 
 .content {
-    /* map background for the main area */
-    /* background: url('https://queitmvjucbjoeodsgqk.supabase.co/storage/v1/object/public/maps/almagro.png') no-repeat center center; */
-    background: url('https://queitmvjucbjoeodsgqk.supabase.co/storage/v1/object/public/maps/map-bg-green.jpg') no-repeat center center;
+    background: var(--content-theme-bg-gradient);
+    background-repeat: no-repeat;
     background-size: cover;
-    /* red tint overlay blended with the map */
-    /* background-color: rgba(140, 86, 28, 0.4); */
-    background-blend-mode: multiply;
     flex: 1;
     padding: 0;
     overflow-y: auto;
     outline: none;
-}
-
-.content.content-theme-bg-only {
-    background: var(--content-theme-bg-gradient);
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-blend-mode: normal;
 }
 
 

--- a/features/character-sheets/index.html
+++ b/features/character-sheets/index.html
@@ -75,8 +75,45 @@
     <div class="beta-bg"></div>
 
     <div class="beta-shell">
+        <!-- ==================== SKELETON LOADER ==================== -->
+        <div id="sheet-skeleton" class="sheet-skeleton" aria-hidden="true">
+            <!-- Header skeleton -->
+            <div class="skel-header">
+                <div class="skel-avatar skel-pulse"></div>
+                <div class="skel-identity">
+                    <div class="skel-identity-row">
+                        <div class="skel-field skel-field--wide skel-pulse"></div>
+                        <div class="skel-field skel-pulse"></div>
+                        <div class="skel-field skel-field--narrow skel-pulse"></div>
+                        <div class="skel-field skel-pulse"></div>
+                    </div>
+                    <div class="skel-identity-row">
+                        <div class="skel-field skel-pulse"></div>
+                        <div class="skel-field skel-pulse"></div>
+                        <div class="skel-field skel-pulse"></div>
+                        <div class="skel-field skel-pulse"></div>
+                    </div>
+                </div>
+            </div>
+            <!-- 3-column grid skeleton -->
+            <div class="skel-grid">
+                <div class="skel-col skel-col--left">
+                    <div class="skel-card skel-card--tall skel-pulse"></div>
+                    <div class="skel-card skel-pulse"></div>
+                    <div class="skel-card skel-card--short skel-pulse"></div>
+                </div>
+                <div class="skel-col skel-col--center">
+                    <div class="skel-card skel-card--tall skel-pulse"></div>
+                    <div class="skel-card skel-card--tall skel-pulse"></div>
+                </div>
+                <div class="skel-col skel-col--right">
+                    <div class="skel-card skel-card--tabs skel-pulse"></div>
+                </div>
+            </div>
+        </div>
+
         <!-- ==================== HEADER ==================== -->
-        <header class="beta-header">
+        <header class="beta-header sheet-content-hidden">
             <a class="profile-back-link" id="profile-link" href="../../index.html#character-sheets" aria-label="Volver">
                 <input type="hidden" id="header-logo-value" name="logo" value="G">
                 <p id="header-logo-display" class="header-clan-sigil">G</p>
@@ -150,7 +187,7 @@
         </header>
 
         <!-- ==================== MAIN GRID ==================== -->
-        <main class="beta-grid">
+        <main class="beta-grid sheet-content-hidden">
 
             <!-- ========== CORE COLUMN (LEFT) ========== -->
             <aside class="core-column">

--- a/features/character-sheets/script.js
+++ b/features/character-sheets/script.js
@@ -376,6 +376,13 @@ function loadCharacterData() {
   // Left empty or used as fallback
 }
 
+function revealSheet() {
+  const skel = document.getElementById("sheet-skeleton");
+  if (skel) skel.classList.add("hidden");
+  document.querySelector(".beta-header")?.classList.remove("sheet-content-hidden");
+  document.querySelector(".beta-grid")?.classList.remove("sheet-content-hidden");
+}
+
 const sheetLoaderModule = window.ABNSheetLoader;
 if (sheetLoaderModule) {
   sheetLoaderModule.configure({
@@ -384,9 +391,11 @@ if (sheetLoaderModule) {
       document.title = "Cargando...";
     },
     onUserMissing: () => {
+      revealSheet();
       window.location.href = "../../index.html";
     },
     onSheetIdMissing: () => {
+      revealSheet();
       window.location.href = "../../index.html#character-sheets";
     },
     onSheetLoaded: ({ id, sheet, user }) => {
@@ -413,11 +422,14 @@ if (sheetLoaderModule) {
         });
         void notesApi.refresh?.();
       }
+      revealSheet();
     },
     onSheetNotFound: () => {
+      revealSheet();
       alert("No se encontró la hoja de personaje.");
     },
     onError: (error) => {
+      revealSheet();
       console.error(error);
       alert("Error al cargar la hoja de personaje.");
     },

--- a/features/character-sheets/style.css
+++ b/features/character-sheets/style.css
@@ -4933,6 +4933,128 @@ html[data-sheet-mode="play"] .attack-item:focus-within .attack-item-header {
 }
 
 /* ================================================
+   SKELETON LOADER
+   ================================================ */
+
+.sheet-content-hidden {
+	visibility: hidden;
+}
+
+.sheet-skeleton {
+	display: contents;
+}
+
+.sheet-skeleton.hidden {
+	display: none;
+}
+
+/* Shimmer pulse animation */
+@keyframes skel-shimmer {
+	0%   { opacity: 0.45; }
+	50%  { opacity: 0.7; }
+	100% { opacity: 0.45; }
+}
+
+.skel-pulse {
+	background: var(--color-bg-raised, #2e2e31);
+	border-radius: 8px;
+	animation: skel-shimmer 1.4s ease-in-out infinite;
+}
+
+/* --- Header skeleton --- */
+.skel-header {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	gap: 16px;
+	align-items: start;
+	margin-bottom: 18px;
+}
+
+.skel-avatar {
+	width: 88px;
+	height: 88px;
+	border-radius: 6px;
+}
+
+.skel-identity {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	padding-top: 4px;
+}
+
+.skel-identity-row {
+	display: grid;
+	grid-template-columns: 1.6fr 1fr 0.6fr 1fr;
+	gap: 12px;
+}
+
+.skel-field {
+	height: 36px;
+	border-radius: 4px;
+}
+
+.skel-field--wide  { grid-column: span 1; }
+.skel-field--narrow { grid-column: span 1; }
+
+/* --- 3-column grid skeleton --- */
+.skel-grid {
+	display: grid;
+	grid-template-columns: minmax(235px, 285px) minmax(560px, 1fr) minmax(300px, 390px);
+	gap: 14px;
+	align-items: start;
+	min-height: 0;
+	height: 100%;
+}
+
+.skel-col {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+
+.skel-card {
+	border-radius: 12px;
+	min-height: 120px;
+}
+
+.skel-card--tall  { min-height: 240px; }
+.skel-card--short { min-height: 80px; }
+.skel-card--tabs  { min-height: 100%; }
+
+/* Responsive: match real grid breakpoints */
+@media (max-width: 1250px) {
+	.skel-grid {
+		grid-template-columns: minmax(260px, 320px) 1fr;
+	}
+	.skel-col--right {
+		grid-column: 1 / -1;
+	}
+	.skel-card--tabs {
+		min-height: 200px;
+	}
+}
+
+@media (max-width: 800px) {
+	.skel-header {
+		grid-template-columns: 1fr;
+	}
+	.skel-avatar {
+		width: 88px;
+		height: 88px;
+	}
+	.skel-identity-row {
+		grid-template-columns: 1fr 1fr;
+	}
+	.skel-grid {
+		grid-template-columns: 1fr;
+	}
+	.skel-card--tabs {
+		min-height: 200px;
+	}
+}
+
+/* ================================================
    RESPONSIVE BREAKPOINTS
    ================================================ */
 

--- a/js/router.js
+++ b/js/router.js
@@ -144,22 +144,8 @@ function setActiveSidebarItem(baseHash) {
   document.getElementById(targetId)?.classList.add("active");
 }
 
-function updateContentBackgroundMode(baseHash) {
-  const contentShell = document.querySelector("main.content");
-  if (!contentShell) return;
-  const useFlatThemeBackground =
-    baseHash === "settings" ||
-    baseHash === "chronicles" ||
-    baseHash === "chronicle" ||
-    baseHash === "active-session" ||
-    baseHash === "revelations-archive" ||
-    baseHash === "character-sheets" ||
-    baseHash === "resource-manager" ||
-    baseHash === "welcome" ||
-    baseHash === "login" ||
-    baseHash === "register" ||
-    baseHash === "user";
-  contentShell.classList.toggle("content-theme-bg-only", useFlatThemeBackground);
+function updateContentBackgroundMode() {
+  // Map background removed — all routes now use theme gradient via .content CSS.
 }
 
 function bindFragmentActions(contentEl) {


### PR DESCRIPTION
## Summary
- Add shimmer skeleton loader to the character sheet (avatar, identity header, 3-column grid) shown while data loads from Supabase
- Remove old map background image from `.content` — all routes now use the theme gradient
- Clean up `updateContentBackgroundMode` and `content-theme-bg-only` class (no longer needed)

## Test plan
- [ ] Open a character sheet and verify skeleton shows briefly before content appears
- [ ] Navigate between routes and confirm no map background bleeds through
- [ ] Check responsive breakpoints (< 1250px, < 800px) for skeleton layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)